### PR TITLE
JPA Entity Fix: 엔티티 수정

### DIFF
--- a/src/main/java/com/dsmbamboo/api/domains/posts/model/Article.java
+++ b/src/main/java/com/dsmbamboo/api/domains/posts/model/Article.java
@@ -33,8 +33,8 @@ public class Article extends Auditable {
     @Column
     private String facebookLink;
 
-    @ManyToOne
-    private Category category;
+    @OneToMany
+    private List<Category> categories;
 
     @ManyToOne
     private User approver;

--- a/src/main/java/com/dsmbamboo/api/domains/posts/model/Category.java
+++ b/src/main/java/com/dsmbamboo/api/domains/posts/model/Category.java
@@ -23,4 +23,7 @@ public class Category extends Auditable {
     @Column(nullable = false)
     private String name;
 
+    @Column(nullable = false, name = "admin_only_flag")
+    private boolean isAdminOnly;
+
 }

--- a/src/main/java/com/dsmbamboo/api/domains/users/model/User.java
+++ b/src/main/java/com/dsmbamboo/api/domains/users/model/User.java
@@ -8,6 +8,7 @@ import lombok.NoArgsConstructor;
 import org.springframework.data.annotation.LastModifiedDate;
 
 import javax.persistence.*;
+import javax.validation.constraints.Size;
 import java.time.LocalDateTime;
 import java.util.Arrays;
 import java.util.List;
@@ -41,9 +42,11 @@ public class User extends Auditable {
     @Column(name = "active_flag")
     private boolean isActive;
 
+    @Size(max = 1000)
     @Column
     private String deviceToken;
 
+    @Size(max = 1000)
     @Column
     private String refreshToken;
 


### PR DESCRIPTION
### 변경사항
- Article이 여러 개의 Category를 가질 수 있도록 수정
- User의 `refresh_token` column 길이 수정(255 -> 1000)