### PR TITLE
`publishedId` Sequence Generator 구현

### DIFF
--- a/src/main/java/com/dsmbamboo/api/domains/posts/exception/SequenceNotFoundException.java
+++ b/src/main/java/com/dsmbamboo/api/domains/posts/exception/SequenceNotFoundException.java
@@ -1,0 +1,8 @@
+package com.dsmbamboo.api.domains.posts.exception;
+
+import org.springframework.http.HttpStatus;
+import org.springframework.web.bind.annotation.ResponseStatus;
+
+@ResponseStatus(value = HttpStatus.NOT_FOUND, reason = "Sequence has not found.")
+public class SequenceNotFoundException extends RuntimeException {
+}

--- a/src/main/java/com/dsmbamboo/api/domains/posts/model/PublishedIdSequence.java
+++ b/src/main/java/com/dsmbamboo/api/domains/posts/model/PublishedIdSequence.java
@@ -1,0 +1,33 @@
+package com.dsmbamboo.api.domains.posts.model;
+
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+import javax.persistence.*;
+
+@Getter
+@Entity
+@NoArgsConstructor
+@AllArgsConstructor
+public class PublishedIdSequence {
+
+    public static final Long NOTICE_SEQUENCE_ID = 1L;
+    public static final Long ARTICLE_SEQUENCE_ID = 2L;
+
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    private Long id;
+
+    @Column
+    private Long sequence;
+
+    @Column(nullable = false)
+    private String description;
+
+    public PublishedIdSequence updateSequence() {
+        this.sequence += 1;
+        return this;
+    }
+
+}

--- a/src/main/java/com/dsmbamboo/api/domains/posts/model/PublishedIdSequenceRepository.java
+++ b/src/main/java/com/dsmbamboo/api/domains/posts/model/PublishedIdSequenceRepository.java
@@ -1,0 +1,8 @@
+package com.dsmbamboo.api.domains.posts.model;
+
+import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.stereotype.Repository;
+
+@Repository
+public interface PublishedIdSequenceRepository extends JpaRepository<PublishedIdSequence, Long> {
+}

--- a/src/main/java/com/dsmbamboo/api/domains/posts/service/PublishedIdGenerator.java
+++ b/src/main/java/com/dsmbamboo/api/domains/posts/service/PublishedIdGenerator.java
@@ -1,0 +1,7 @@
+package com.dsmbamboo.api.domains.posts.service;
+
+public interface PublishedIdGenerator {
+
+    Long getNextNoticePublishedId();
+
+}

--- a/src/main/java/com/dsmbamboo/api/domains/posts/service/PublishedIdGeneratorImpl.java
+++ b/src/main/java/com/dsmbamboo/api/domains/posts/service/PublishedIdGeneratorImpl.java
@@ -1,0 +1,29 @@
+package com.dsmbamboo.api.domains.posts.service;
+
+import com.dsmbamboo.api.domains.posts.exception.SequenceNotFoundException;
+import com.dsmbamboo.api.domains.posts.model.PublishedIdSequence;
+import com.dsmbamboo.api.domains.posts.model.PublishedIdSequenceRepository;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+
+import java.util.Optional;
+
+import static com.dsmbamboo.api.domains.posts.model.PublishedIdSequence.NOTICE_SEQUENCE_ID;
+
+@Service
+@RequiredArgsConstructor
+public class PublishedIdGeneratorImpl implements PublishedIdGenerator {
+
+    private final PublishedIdSequenceRepository sequenceRepository;
+
+    @Override
+    public Long getNextNoticePublishedId() {
+        return sequenceRepository.findById(NOTICE_SEQUENCE_ID)
+                .or(() -> Optional.of(new PublishedIdSequence(NOTICE_SEQUENCE_ID, 0L, "Notice")))
+                .map(PublishedIdSequence::updateSequence)
+                .map(sequenceRepository::save)
+                .map(PublishedIdSequence::getSequence)
+                .orElseThrow(SequenceNotFoundException::new);
+    }
+
+}


### PR DESCRIPTION
### 변경사항
- `publishedId` Sequence Generator 구현

### 변경사유
- 공지사항, 게시글에 기록되는 `publishedId`는 게시글을 승인 시 부여되기 때문에 auto increment를 적용하기 어렵다.
- 또한 공지사항, 초안, 게시글 모두 한 테이블에서 관리되므로 이를 구별할 수 있는 대책이 필요했다.