### PR TITLE
[fix] add: `@Transactional` on NoticeService::create

### DIFF
--- a/src/main/java/com/dsmbamboo/api/domains/posts/service/NoticeServiceImpl.java
+++ b/src/main/java/com/dsmbamboo/api/domains/posts/service/NoticeServiceImpl.java
@@ -15,6 +15,7 @@ import org.springframework.data.domain.Page;
 import org.springframework.data.domain.Pageable;
 import org.springframework.stereotype.Service;
 
+import javax.transaction.Transactional;
 import java.util.List;
 import java.util.Optional;
 
@@ -38,6 +39,7 @@ public class NoticeServiceImpl implements NoticeService {
     }
 
     @Override
+    @Transactional
     public NoticeResponse create(CreateArticleRequest request) {
         if (!isContainsNoticeCategory(request.getCategories()))
             throw new InvalidCategoryException();


### PR DESCRIPTION
### 변경사항
- 공지사항 작성 메서드에 `@Transactional` 어노테이션 추가

### 변경사유
- DB 오류 발생 시 published_id_sequence가 원래대로 복귀되지 않아 id가 중간에 누락되는 문제 발생