### PR TITLE
[FIX] DraftResponse.id to Article.id (not publishedId)

### DIFF
--- a/src/main/java/com/dsmbamboo/api/domains/posts/dto/DraftResponse.java
+++ b/src/main/java/com/dsmbamboo/api/domains/posts/dto/DraftResponse.java
@@ -23,7 +23,7 @@ public class DraftResponse {
     private String recentCreatedAt;
 
     public DraftResponse(Article article) {
-        this.id = article.getPublishedId();
+        this.id = article.getId();
         this.title = article.getTitle();
         this.content = article.getContent();
         this.facebookLink = article.getFacebookLink();


### PR DESCRIPTION
### 변경사항
- `DraftResponse.id`를 기존 `Article.publishedId`에서 `Article.id`로 변경

### 변경사유
- `DRAFT` 타입의 게시글은 publishedId를 할당받지 않은 상태
- draft 조회시 null을 반환하게 되므로 404 NOT FOUND 반환하는 문제 발생