### PR TITLE
Generate Document Key: 재학생 인증 문항 응답 기능 구현

### DIFF
--- a/src/main/java/com/dsmbamboo/api/domains/images/service/S3ImageServiceImpl.java
+++ b/src/main/java/com/dsmbamboo/api/domains/images/service/S3ImageServiceImpl.java
@@ -52,7 +52,6 @@ public class S3ImageServiceImpl implements ImageService {
     }
 
     private String upload(Long userId, MultipartFile image) {
-        System.out.println(image.getOriginalFilename());
         String filename = userId + "/" + UUID.randomUUID().toString() + "." + image.getContentType().substring(6);
         try {
             amazonS3.putObject(new PutObjectRequest(bucket, filename, image.getInputStream(), null)

--- a/src/main/java/com/dsmbamboo/api/domains/questions/controller/QuestionController.java
+++ b/src/main/java/com/dsmbamboo/api/domains/questions/controller/QuestionController.java
@@ -1,5 +1,7 @@
 package com.dsmbamboo.api.domains.questions.controller;
 
+import com.dsmbamboo.api.domains.questions.dto.CreateDocumentKeyRequest;
+import com.dsmbamboo.api.domains.questions.dto.DocumentKeyResponse;
 import com.dsmbamboo.api.domains.questions.dto.CreateQuestionRequest;
 import com.dsmbamboo.api.domains.questions.dto.QuestionResponse;
 import com.dsmbamboo.api.domains.questions.exception.QuestionNotFoundException;
@@ -30,6 +32,11 @@ public class QuestionController {
         return questionService.findByRandomId()
                 .map(QuestionResponse::new)
                 .orElseThrow(QuestionNotFoundException::new);
+    }
+
+    @PostMapping("/{questionId}/answer")
+    public DocumentKeyResponse generateDocumentKey(@PathVariable Long questionId, @RequestBody @Valid CreateDocumentKeyRequest request) {
+        return new DocumentKeyResponse(questionService.generateDocumentKey(questionId, request));
     }
 
 }

--- a/src/main/java/com/dsmbamboo/api/domains/questions/dto/CreateDocumentKeyRequest.java
+++ b/src/main/java/com/dsmbamboo/api/domains/questions/dto/CreateDocumentKeyRequest.java
@@ -1,0 +1,14 @@
+package com.dsmbamboo.api.domains.questions.dto;
+
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Getter
+@NoArgsConstructor
+@AllArgsConstructor
+public class CreateDocumentKeyRequest {
+
+    private String answer;
+
+}

--- a/src/main/java/com/dsmbamboo/api/domains/questions/dto/DocumentKeyResponse.java
+++ b/src/main/java/com/dsmbamboo/api/domains/questions/dto/DocumentKeyResponse.java
@@ -1,0 +1,14 @@
+package com.dsmbamboo.api.domains.questions.dto;
+
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Getter
+@NoArgsConstructor
+@AllArgsConstructor
+public class DocumentKeyResponse {
+
+    private String documentKey;
+
+}

--- a/src/main/java/com/dsmbamboo/api/domains/questions/exception/IncorrectAnswerException.java
+++ b/src/main/java/com/dsmbamboo/api/domains/questions/exception/IncorrectAnswerException.java
@@ -1,0 +1,8 @@
+package com.dsmbamboo.api.domains.questions.exception;
+
+import org.springframework.http.HttpStatus;
+import org.springframework.web.bind.annotation.ResponseStatus;
+
+@ResponseStatus(value = HttpStatus.FORBIDDEN,reason = "Incorrect question answer submitted.")
+public class IncorrectAnswerException extends RuntimeException {
+}

--- a/src/main/java/com/dsmbamboo/api/domains/questions/service/StudentQuestionService.java
+++ b/src/main/java/com/dsmbamboo/api/domains/questions/service/StudentQuestionService.java
@@ -1,5 +1,6 @@
 package com.dsmbamboo.api.domains.questions.service;
 
+import com.dsmbamboo.api.domains.questions.dto.CreateDocumentKeyRequest;
 import com.dsmbamboo.api.domains.questions.dto.CreateQuestionRequest;
 import com.dsmbamboo.api.domains.questions.model.StudentQuestion;
 
@@ -9,5 +10,7 @@ public interface StudentQuestionService {
 
     StudentQuestion create(CreateQuestionRequest request);
     Optional<StudentQuestion> findByRandomId();
+
+    String generateDocumentKey(Long questionId, CreateDocumentKeyRequest request);
 
 }

--- a/src/main/java/com/dsmbamboo/api/domains/questions/service/StudentQuestionServiceImpl.java
+++ b/src/main/java/com/dsmbamboo/api/domains/questions/service/StudentQuestionServiceImpl.java
@@ -1,8 +1,14 @@
 package com.dsmbamboo.api.domains.questions.service;
 
+import com.dsmbamboo.api.domains.questions.dto.CreateDocumentKeyRequest;
 import com.dsmbamboo.api.domains.questions.dto.CreateQuestionRequest;
+import com.dsmbamboo.api.domains.questions.exception.IncorrectAnswerException;
+import com.dsmbamboo.api.domains.questions.exception.QuestionNotFoundException;
 import com.dsmbamboo.api.domains.questions.model.StudentQuestion;
 import com.dsmbamboo.api.domains.questions.model.StudentQuestionRepository;
+import com.dsmbamboo.api.domains.users.security.AuthenticationFacade;
+import com.dsmbamboo.api.domains.users.security.JwtTokenProvider;
+import com.dsmbamboo.api.domains.users.security.UserPrincipal;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.security.crypto.password.PasswordEncoder;
@@ -16,12 +22,12 @@ import java.util.Optional;
 public class StudentQuestionServiceImpl implements StudentQuestionService {
 
     private final PasswordEncoder passwordEncoder;
+    private final JwtTokenProvider jwtTokenProvider;
+    private final AuthenticationFacade authenticationFacade;
     private final StudentQuestionRepository questionRepository;
 
     @Override
     public StudentQuestion create(CreateQuestionRequest request) {
-        log.warn("QUESTION: " + request.getQuestion());
-        log.warn("ANSWER: " + request.getAnswer());
         StudentQuestion question = StudentQuestion.builder()
                 .id(0L)
                 .question(request.getQuestion())
@@ -34,6 +40,25 @@ public class StudentQuestionServiceImpl implements StudentQuestionService {
     @Override
     public Optional<StudentQuestion> findByRandomId() {
         return questionRepository.findByRandomId();
+    }
+
+    @Override
+    public String generateDocumentKey(Long questionId, CreateDocumentKeyRequest request) {
+        return questionRepository.findById(questionId)
+                .map(question -> {
+                    if (!isCorrectAnswer(request.getAnswer(), question.getAnswer()))
+                        throw new IncorrectAnswerException();
+                    return question;
+                })
+                .map(question -> {
+                    Long userId = ((UserPrincipal) authenticationFacade.getAuthentication().getPrincipal()).getId();
+                    return jwtTokenProvider.createDocumentKey(userId.toString());
+                })
+                .orElseThrow(QuestionNotFoundException::new);
+    }
+
+    private boolean isCorrectAnswer(String rawAnswer, String encodedAnswer) {
+        return passwordEncoder.matches(rawAnswer, encodedAnswer);
     }
 
 }

--- a/src/main/java/com/dsmbamboo/api/domains/users/security/JwtTokenProvider.java
+++ b/src/main/java/com/dsmbamboo/api/domains/users/security/JwtTokenProvider.java
@@ -27,6 +27,9 @@ public class JwtTokenProvider {
     @Value("${auth.jwt.exp.refresh}")
     private int refreshTokenExpiration;
 
+    @Value("${auth.jwt.exp.document}")
+    private int documentKeyExpiration;
+
     @Value("${auth.jwt.header}")
     private String header;
 

--- a/src/main/java/com/dsmbamboo/api/domains/users/security/JwtTokenProvider.java
+++ b/src/main/java/com/dsmbamboo/api/domains/users/security/JwtTokenProvider.java
@@ -58,6 +58,15 @@ public class JwtTokenProvider {
                 .sign(Algorithm.HMAC512(secretKey));
     }
 
+    public String createDocumentKey(String username) {
+        return JWT.create()
+                .withSubject(username)
+                .withExpiresAt(new Date(System.currentTimeMillis() + documentKeyExpiration * 1000))
+                .withIssuedAt(new Date())
+                .withIssuer("dsmbamboo.document_key")
+                .sign(Algorithm.HMAC512(secretKey));
+    }
+
     public Authentication getAuthentication(String token) {
         UserPrincipal userDetails = userDetailsService.loadUserByUsername(getUsername(token));
         return new UsernamePasswordAuthenticationToken(userDetails, "", userDetails.getAuthorities());

--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -27,6 +27,7 @@ auth:
     exp:
       access: ${JWT_EXP_ACCESS}
       refresh: ${JWT_EXP_REFRESH}
+      document: ${JWT_EXP_DOCUMENT}
 
 cloud:
   aws:

--- a/src/test/resources/application.yml
+++ b/src/test/resources/application.yml
@@ -13,6 +13,7 @@ auth:
     exp:
       access: 100
       refresh: 300
+      document: 300
 
 cloud:
   aws:


### PR DESCRIPTION
### 변경사항
- 초안 작성을 위한 재학생 인증 문항 응답 기능 구현

### 변경사유
- 초안 작성을 위해서는 재학생 인증 문항에 정답을 입력해야
  - 재학생 인증 문항의 정답은 암호화 후 저장
- 비상태성 유지 위해 인증 문항에 정답을 입력한 경우 AccessToken과 별도로 작동하는 document key(JWT) 발급
- 초안 작성 시 가용 document key로 접근 권한을 구분함
